### PR TITLE
Set Content-Length correctly when body contains multi-byte characters 

### DIFF
--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -30,12 +30,12 @@ module Rack
       status, headers, response = @app.call(env)
       if callback && headers['Content-Type'] =~ /json/i
         response = pad(callback, response)
-        headers['Content-Length'] = response.first.length.to_s
+        headers['Content-Length'] = response.first.bytesize.to_s
         headers['Content-Type'] = 'application/javascript'
       elsif @carriage_return && headers['Content-Type'] =~ /json/i
         # add a \n after the response if this is a json (not JSONP) response
         response = carriage_return(response)
-        headers['Content-Length'] = response.first.length.to_s
+        headers['Content-Length'] = response.first.bytesize.to_s
       end
       [status, headers, response]
     end

--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -7,8 +7,6 @@ module Rack
   #
   class JSONP
 
-    VERSION = "1.2.0"
-
     def initialize(app, options = {})
       @app = app
       @carriage_return = options[:carriage_return] || false

--- a/rack-jsonp.gemspec
+++ b/rack-jsonp.gemspec
@@ -1,12 +1,8 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib/', __FILE__)
-$:.unshift lib unless $:.include?(lib)
-
-require 'rack/jsonp'
 
 Gem::Specification.new do |s|
   s.name                      = "rack-jsonp"
-  s.version                   = Rack::JSONP::VERSION
+  s.version                   = "1.2.0"
   s.platform                  = Gem::Platform::RUBY
   s.required_ruby_version     = '>= 1.8'
   s.required_rubygems_version = ">= 1.3"


### PR DESCRIPTION
Turns out the Content-Length header must be set to the number of bytes in the content, not the number of characters.

Best to call bytesize rather than length.
