### PR TITLE
fix(escaping): Always escape U+2028 and U+2029 tx: https://github.com/judofyr/rack-contrib/commit/24f3da12ea7f763826d0166591a45eba2d9bfce5

### DIFF
--- a/lib/rack/jsonp.rb
+++ b/lib/rack/jsonp.rb
@@ -56,7 +56,9 @@ module Rack
     # since JSON is returned as a full string.
     #
     def pad(callback, response, body = "")
-      response.each{ |s| body << s.to_s }
+      response.each do |s|
+        body << s.to_s.gsub("\u2028", '\u2028').gsub("\u2029", '\u2029')
+      end
       close(response)
       ["#{callback}(#{body})"]
     end

--- a/spec/rack_jsonp_spec.rb
+++ b/spec/rack_jsonp_spec.rb
@@ -159,6 +159,14 @@ describe Rack::JSONP do
       body = Rack::JSONP.new(app, :carriage_return => true).call(request).last
       body.should == ["#{callback}(#{test_body})"]
     end
+    it 'replaces' do
+      test_body = "{\"bar\":\"\u2028 and \u2029\"}"
+      callback = 'foo'
+      app = lambda { |env| [200, {'Content-Type' => 'application/json'}, [test_body]] }
+      request = Rack::MockRequest.env_for("/", :params => "foo=bar&callback=#{callback}")
+      body = Rack::JSONP.new(app).call(request).last
+      body.join.should_not =~ /\u2028|\u2029/
+    end
   end
 
   it "should not change anything if no callback param is provided" do


### PR DESCRIPTION
http://timelessrepo.com/json-isnt-a-javascript-subset
